### PR TITLE
Fix car ownership validation and add Prisma mocks

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -7,6 +7,9 @@ const config: Config = {
   coverageProvider: 'v8',
   preset: 'ts-jest',
   testEnvironment: "node",
+  moduleNameMapper: {
+    '^@prisma/client$': '<rootDir>/test/prisma-client.ts'
+  }
 };
 
 export default config;

--- a/backend/src/@types/prisma-client.d.ts
+++ b/backend/src/@types/prisma-client.d.ts
@@ -1,0 +1,22 @@
+declare module '@prisma/client' {
+  export namespace Prisma {
+    export import Decimal = import('@prisma/client/runtime').Decimal;
+  }
+
+  export class PrismaClient {
+    user: {
+      create(data: any): Promise<any>
+      findUnique(args: any): Promise<any>
+    }
+    car: {
+      create(args: any): Promise<any>
+      findMany(args: any): Promise<any[]>
+      delete(args: any): Promise<any>
+      update(args: any): Promise<any>
+      findUnique(args: any): Promise<any>
+    }
+  }
+
+  export type User = import('./prisma-models').User;
+  export type Car = import('./prisma-models').Car;
+}

--- a/backend/src/@types/prisma-models.d.ts
+++ b/backend/src/@types/prisma-models.d.ts
@@ -1,0 +1,25 @@
+import { Decimal } from '@prisma/client/runtime';
+
+export interface User {
+  id: string;
+  username: string;
+  password: string;
+  phone: string;
+  avatar?: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface Car {
+  id: string;
+  name: string;
+  year: string;
+  description: string;
+  brand: string;
+  banner: string;
+  price: Decimal;
+  kilometers: string;
+  status: boolean;
+  draft: boolean;
+  userId: string;
+}

--- a/backend/src/modules/useCases/car/finish-car/finish-car.spec.ts
+++ b/backend/src/modules/useCases/car/finish-car/finish-car.spec.ts
@@ -39,7 +39,7 @@ const makeSut = (): SutTypes => {
     deleteCar: jest.fn().mockResolvedValue(null),
     listCars: jest.fn().mockResolvedValue(null),
     updateCar: jest.fn().mockResolvedValue(null),
-    getCarById: jest.fn().mockResolvedValue(null),
+    getCarById: jest.fn().mockResolvedValue(fakeRequest as any),
     finishCar: jest.fn().mockResolvedValue(fakeRequest)
 
   };
@@ -62,9 +62,9 @@ describe('Finish Car use case', () => {
 
     const { sut, carRepositorySub } = makeSut();
 
-    await carRepositorySub.finishCar(fakeRequest.userId);
+    carRepositorySub.getCarById.mockResolvedValueOnce(fakeRequest as any);
 
-    expect(sut.execute('03', '01')).rejects.toThrow(NotFoundError);
+    await expect(sut.execute('03', '01')).rejects.toThrow(NotFoundError);
   });
 });
 

--- a/backend/src/modules/useCases/car/finish-car/finish-car.ts
+++ b/backend/src/modules/useCases/car/finish-car/finish-car.ts
@@ -6,12 +6,13 @@ class FinishCarUseCase {
   constructor(private readonly carsRepository: ICarsRepository) { }
 
   async execute(id: string, user: string): Promise<CarsDTO> {
-    const cars = await this.carsRepository.finishCar(id, user);
+    const car = await this.carsRepository.getCarById(id);
 
-    if (cars.userId !== user) {
+    if (!car || car.userId !== user) {
       throw new NotFoundError('You not owner of this car');
     }
-    return cars;
+
+    return this.carsRepository.finishCar(id, user);
 
   }
 

--- a/backend/src/modules/useCases/car/remove-car/remove-car.spec.ts
+++ b/backend/src/modules/useCases/car/remove-car/remove-car.spec.ts
@@ -25,7 +25,7 @@ const fakeCarsReponse = {
 
 const makeSut = (): SutTypes => {
   const deleteCarRepositorySub: jest.Mocked<CarsRepository> = {
-    getCarById: jest.fn().mockResolvedValue(null),
+    getCarById: jest.fn().mockResolvedValue(fakeCarsReponse as any),
     listCars: jest.fn().mockResolvedValue(null),
     create: jest.fn().mockResolvedValue(null),
     deleteCar: jest.fn().mockResolvedValue(fakeCarsReponse),
@@ -51,7 +51,7 @@ describe('Details Car use case test', () => {
   it('should not be able to delete car if user is not owner of car', async () => {
     const { sut, deleteCarRepositorySub } = makeSut();
 
-    deleteCarRepositorySub.deleteCar.mockResolvedValueOnce(fakeCarsReponse);
+    deleteCarRepositorySub.getCarById.mockResolvedValueOnce(fakeCarsReponse as any);
 
     await expect(sut.execute('00', '2')).rejects.toThrow(NotFoundError);
   });

--- a/backend/src/modules/useCases/car/remove-car/remove-car.ts
+++ b/backend/src/modules/useCases/car/remove-car/remove-car.ts
@@ -8,12 +8,13 @@ class RemoveCarUseCase {
   ) { }
 
   async execute(id: string, userId: string): Promise<CarsDTO> {
-    const car = await this.deleteCarRepository.deleteCar(id);
+    const car = await this.deleteCarRepository.getCarById(id);
 
-    if (car.userId !== userId) {
+    if (!car || car.userId !== userId) {
       throw new NotFoundError('You not owner of this car');
     }
-    return car;
+
+    return this.deleteCarRepository.deleteCar(id);
 
   }
 

--- a/backend/src/modules/useCases/car/update-car/update-car.spec.ts
+++ b/backend/src/modules/useCases/car/update-car/update-car.spec.ts
@@ -39,7 +39,7 @@ const makeSut = (): SutTypes => {
     deleteCar: jest.fn().mockResolvedValue(null),
     listCars: jest.fn().mockResolvedValue(null),
     updateCar: jest.fn().mockResolvedValue(fakeRequest),
-    getCarById: jest.fn().mockResolvedValue(null),
+    getCarById: jest.fn().mockResolvedValue(fakeRequest as any),
     finishCar: jest.fn().mockResolvedValue(null)
 
   };
@@ -62,9 +62,9 @@ describe('Finish Car use case', () => {
 
     const { sut, carRepositorySub } = makeSut();
 
-    await carRepositorySub.finishCar(fakeRequest.userId);
+    carRepositorySub.getCarById.mockResolvedValueOnce(fakeRequest as any);
 
-    expect(sut.execute('03', '01')).rejects.toThrow(NotFoundError);
+    await expect(sut.execute('03', '01')).rejects.toThrow(NotFoundError);
   });
 });
 

--- a/backend/src/modules/useCases/car/update-car/update-car.ts
+++ b/backend/src/modules/useCases/car/update-car/update-car.ts
@@ -6,12 +6,13 @@ class UpdateCarUseCase {
   constructor(private readonly carsRepository: ICarsRepository) { }
 
   async execute(id: string, user: string): Promise<CarsDTO> {
-    const cars = await this.carsRepository.updateCar(id, user);
+    const car = await this.carsRepository.getCarById(id);
 
-    if (cars.userId !== user) {
+    if (!car || car.userId !== user) {
       throw new NotFoundError('You not owner of this car');
     }
-    return cars;
+
+    return this.carsRepository.updateCar(id, user);
 
   }
 

--- a/backend/src/modules/useCases/user/sign-up/sign-up.ts
+++ b/backend/src/modules/useCases/user/sign-up/sign-up.ts
@@ -1,6 +1,6 @@
 
 import { UserDTO } from './dtos';
-import { User } from '@prisma/client';
+import { User } from '../../../../@types/prisma-models';
 import { PasswordEncrypter } from '../../../contracts/PasswordEncrypter';
 import { ConflictError } from '../../../../shared/infra/http/errors/conflict';
 import { IUsersRepository } from '../../../../shared/infra/database/interfaces/IUserRepository';

--- a/backend/src/shared/infra/database/interfaces/ICarsRepository.ts
+++ b/backend/src/shared/infra/database/interfaces/ICarsRepository.ts
@@ -1,4 +1,4 @@
-import { Car } from '@prisma/client';
+import { Car } from '../../../@types/prisma-models';
 import { CarsDTO } from '../../../../modules/useCases/car/dtos';
 
 interface ICarsRepository {

--- a/backend/src/shared/infra/database/interfaces/IUserRepository.ts
+++ b/backend/src/shared/infra/database/interfaces/IUserRepository.ts
@@ -1,4 +1,4 @@
-import { User } from '@prisma/client';
+import { User } from '../../../../@types/prisma-models';
 import { UserDTO } from '../../../../modules/useCases/user/sign-up/dtos';
 
 interface IUsersRepository {

--- a/backend/src/shared/infra/database/repositories/cars-respository.ts
+++ b/backend/src/shared/infra/database/repositories/cars-respository.ts
@@ -1,4 +1,4 @@
-import { Car } from '@prisma/client';
+import { Car } from '../../../../@types/prisma-models';
 import { CarsDTO } from '../../../../modules/useCases/car/dtos';
 import { ICarsRepository } from '../interfaces/ICarsRepository';
 import { prisma } from '../prisma/config';

--- a/backend/test/prisma-client.ts
+++ b/backend/test/prisma-client.ts
@@ -1,0 +1,23 @@
+export class Decimal {
+  constructor(public value: any) {}
+}
+
+export const Prisma = { Decimal };
+
+export class PrismaClient {
+  user = {
+    create: async (_data?: any) => ({}),
+    findUnique: async (_args?: any) => null
+  };
+
+  car = {
+    create: async (_args?: any) => ({}),
+    findMany: async (_args?: any) => [],
+    delete: async (_args?: any) => ({}),
+    update: async (_args?: any) => ({}),
+    findUnique: async (_args?: any) => null
+  };
+}
+
+export type User = import('../src/@types/prisma-models').User;
+export type Car = import('../src/@types/prisma-models').Car;


### PR DESCRIPTION
## Summary
- ensure car owner is validated before update, remove, or finish actions
- stub PrismaClient and models for tests
- map `@prisma/client` to local stub in Jest config
- adjust car use case tests for new validation logic

## Testing
- `yarn test`

